### PR TITLE
Feature/creating bets

### DIFF
--- a/backend/src/main/java/com/sportisfun/backend/DTOs/AddPickDto.java
+++ b/backend/src/main/java/com/sportisfun/backend/DTOs/AddPickDto.java
@@ -1,0 +1,13 @@
+package com.sportisfun.backend.DTOs;
+
+import com.sportisfun.backend.models.BetOption;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class AddPickDto {
+    @NotNull
+    private Long matchId;
+    @NotNull
+    private BetOption betOption;
+}

--- a/backend/src/main/java/com/sportisfun/backend/DTOs/BetPickDto.java
+++ b/backend/src/main/java/com/sportisfun/backend/DTOs/BetPickDto.java
@@ -1,0 +1,18 @@
+package com.sportisfun.backend.DTOs;
+
+import com.sportisfun.backend.models.BetOption;
+import com.sportisfun.backend.models.BetPickResult;
+import lombok.Builder;
+import lombok.Value;
+
+import java.math.BigDecimal;
+
+@Builder
+@Value
+public class BetPickDto {
+    Long id;
+    Long matchId;
+    BetOption option;
+    BigDecimal selectedOdds;
+    BetPickResult result;
+}

--- a/backend/src/main/java/com/sportisfun/backend/DTOs/BetSlipDto.java
+++ b/backend/src/main/java/com/sportisfun/backend/DTOs/BetSlipDto.java
@@ -1,0 +1,23 @@
+package com.sportisfun.backend.DTOs;
+
+import com.sportisfun.backend.models.BetSlipStatus;
+import lombok.Builder;
+import lombok.Value;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Set;
+
+@Value
+@Builder
+public class BetSlipDto {
+    Long id;
+    BetSlipStatus status;
+    BigDecimal stake;
+    BigDecimal totalOdds;
+    BigDecimal totalWin;
+    BigDecimal potentialWin;
+    LocalDateTime placedAt;
+    LocalDateTime settledAt;
+    Set<BetPickDto> betPicks;
+}

--- a/backend/src/main/java/com/sportisfun/backend/DTOs/PlaceBetSlipRequest.java
+++ b/backend/src/main/java/com/sportisfun/backend/DTOs/PlaceBetSlipRequest.java
@@ -1,0 +1,14 @@
+package com.sportisfun.backend.DTOs;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+import java.math.BigDecimal;
+
+@Data
+public class PlaceBetSlipRequest {
+    @NotNull
+    @DecimalMin("1.00")
+    private BigDecimal stake;
+}

--- a/backend/src/main/java/com/sportisfun/backend/controllers/BetSlipController.java
+++ b/backend/src/main/java/com/sportisfun/backend/controllers/BetSlipController.java
@@ -1,0 +1,40 @@
+package com.sportisfun.backend.controllers;
+
+import com.sportisfun.backend.DTOs.AddPickDto;
+import com.sportisfun.backend.DTOs.BetSlipDto;
+import com.sportisfun.backend.DTOs.PlaceBetSlipRequest;
+import com.sportisfun.backend.security.CustomUserDetails;
+import com.sportisfun.backend.services.BetSlipService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/betslip")
+@RequiredArgsConstructor
+public class BetSlipController {
+    private final BetSlipService betSlipService;
+
+    @GetMapping("/draft")
+    public ResponseEntity<BetSlipDto> getDraft(@AuthenticationPrincipal CustomUserDetails userDetails){
+        BetSlipDto dto = betSlipService.getDraft(userDetails.getId());
+        return dto == null ? ResponseEntity.noContent().build() : ResponseEntity.ok(dto);
+    }
+
+    @PostMapping("/picks")
+    public BetSlipDto addPick(@RequestBody @Valid AddPickDto dto, @AuthenticationPrincipal CustomUserDetails userDetails){
+        return betSlipService.addPick(dto, userDetails.getId());
+    }
+
+    @DeleteMapping("/picks/{pickId}")
+    public BetSlipDto removePick(@PathVariable Long pickId, @AuthenticationPrincipal CustomUserDetails userDetails){
+        return betSlipService.removePick(pickId, userDetails.getId());
+    }
+
+    @PostMapping("/place")
+    public BetSlipDto place(@RequestBody @Valid PlaceBetSlipRequest req, @AuthenticationPrincipal CustomUserDetails userDetails){
+        return betSlipService.place(req, userDetails.getId());
+    }
+}

--- a/backend/src/main/java/com/sportisfun/backend/models/BetPick.java
+++ b/backend/src/main/java/com/sportisfun/backend/models/BetPick.java
@@ -2,10 +2,15 @@ package com.sportisfun.backend.models;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Min;
+import lombok.*;
 
 import java.math.BigDecimal;
 
 @Entity
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class BetPick {
 
     @Id
@@ -13,18 +18,21 @@ public class BetPick {
     private Long id;
 
     @ManyToOne
-    @JoinColumn(name = "match_id")
+    @JoinColumn(name = "match_id", nullable = false)
     private Match match;
 
     @Enumerated(EnumType.STRING)
     private BetOption betOption;
 
-    @Min(value = 1)
-    private BigDecimal odd;
+    @Column(precision = 8, scale = 2, nullable = false)
+    private BigDecimal selectedOdd;
 
-    private boolean correct;
+    @Enumerated(EnumType.STRING)
+    @Column(length = 16, nullable = false)
+    private BetPickResult result = BetPickResult.PENDING;
 
-
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
     @ManyToOne
     @JoinColumn(name = "betSlip_id")
     private BetSlip betSlip;

--- a/backend/src/main/java/com/sportisfun/backend/models/BetPickResult.java
+++ b/backend/src/main/java/com/sportisfun/backend/models/BetPickResult.java
@@ -1,0 +1,7 @@
+package com.sportisfun.backend.models;
+
+public enum BetPickResult {
+    PENDING,
+    WIN,
+    LOSE
+}

--- a/backend/src/main/java/com/sportisfun/backend/models/BetSlip.java
+++ b/backend/src/main/java/com/sportisfun/backend/models/BetSlip.java
@@ -3,14 +3,14 @@ package com.sportisfun.backend.models;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Positive;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 
 @Entity
 @Data
@@ -24,26 +24,83 @@ public class BetSlip {
     private Long id;
 
     @Min(value = 1, message = "Minimal bet stake is $1")
-    @Column(nullable = false)
+    @Column(precision = 12, scale=2)
+    @Positive
     private BigDecimal stake;
 
     @Positive
+    @Column(precision = 14, scale=2)
     private BigDecimal potentialWin;
 
     @Min(1)
+    @Column(precision = 14, scale=2, nullable=false)
     private BigDecimal totalOdds;
 
-    private boolean won;
+    @Enumerated(EnumType.STRING)
+    @Column(length = 16, nullable=false)
+    private BetSlipStatus status = BetSlipStatus.DRAFT;
 
     private LocalDateTime placedAt;
 
+    private LocalDateTime settledAt;
+
+    @Version
+    private Long version;
+
     @ManyToOne
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @OneToMany(
             mappedBy = "betSlip",
-            cascade = CascadeType.ALL
+            cascade = CascadeType.ALL,
+            orphanRemoval = true
     )
-    private List<BetPick> betPicks;
+
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    @Builder.Default
+    private Set<BetPick> betPicks = new LinkedHashSet<>();
+
+
+    public void addPick(BetPick pick) {
+        if(status != BetSlipStatus.DRAFT) throw new IllegalStateException("Cannot add bet pick to existing coupon");
+        pick.setBetSlip(this);
+        betPicks.add(pick);
+        recalcTotals();
+    }
+
+    public void removePick(BetPick pick) {
+        if(status != BetSlipStatus.DRAFT) throw new IllegalStateException("Cannot remove bet pick from placed coupon");
+        betPicks.removeIf(p -> Objects.equals(p.getId(), pick.getId()));
+        recalcTotals();
+    }
+
+    public void place(BigDecimal stake){
+        if(status != BetSlipStatus.DRAFT) throw new IllegalStateException("Cannot place bet slip to placed coupon");
+        this.stake = stake;
+        recalcTotals();
+        this.potentialWin = stake.multiply(totalOdds);
+        this.status = BetSlipStatus.PLACED;
+        this.placedAt = LocalDateTime.now();
+    }
+
+    public void settle(){
+        if(status != BetSlipStatus.PLACED) throw new IllegalStateException("Coupon is not PLACED");
+        boolean allResolved = betPicks.stream().allMatch(p -> p.getResult() != BetPickResult.PENDING);
+        if(!allResolved) return;
+        //this.won = betPicks.stream().allMatch(p -> p.getResult() == BetPickResult.WIN);
+        this.status = BetSlipStatus.SETTLED;
+        settledAt = LocalDateTime.now();
+    }
+
+    public void recalcTotals() {
+        this.totalOdds = betPicks.stream()
+                .map(p -> p.getSelectedOdd())
+                .reduce(BigDecimal.ONE, BigDecimal::multiply);
+        if(stake != null){
+            potentialWin = stake.multiply(totalOdds);
+        }
+    }
+
 }

--- a/backend/src/main/java/com/sportisfun/backend/models/BetSlipStatus.java
+++ b/backend/src/main/java/com/sportisfun/backend/models/BetSlipStatus.java
@@ -1,0 +1,7 @@
+package com.sportisfun.backend.models;
+
+public enum BetSlipStatus {
+    DRAFT,
+    PLACED,
+    SETTLED
+}

--- a/backend/src/main/java/com/sportisfun/backend/models/League.java
+++ b/backend/src/main/java/com/sportisfun/backend/models/League.java
@@ -1,10 +1,8 @@
 package com.sportisfun.backend.models;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.List;
 
@@ -25,6 +23,8 @@ public class League {
     @Column(nullable = false)
     private String country;
 
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
     @OneToMany(
             mappedBy = "league"
     )

--- a/backend/src/main/java/com/sportisfun/backend/models/Match.java
+++ b/backend/src/main/java/com/sportisfun/backend/models/Match.java
@@ -18,31 +18,35 @@ public class Match {
     @Id
     private Long id;
 
-    @ManyToOne
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "league_id")
     private League league;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(nullable = false)
     private Team homeTeam;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(nullable = false)
     private Team awayTeam;
 
     @Column(nullable = false)
     private LocalDateTime startTime;
 
-    @Positive
     private Integer homeGoals;
-    @Positive
     private Integer awayGoals;
 
     private boolean finished = false;
 
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
     @OneToMany(mappedBy = "match")
     private List<BetPick> betPicks;
 
-    @OneToOne(mappedBy = "match", cascade = CascadeType.ALL)
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    @OneToOne(mappedBy = "match", cascade = CascadeType.ALL, fetch = FetchType.LAZY, optional = false)
     private Odds odds;
 }

--- a/backend/src/main/java/com/sportisfun/backend/models/Odds.java
+++ b/backend/src/main/java/com/sportisfun/backend/models/Odds.java
@@ -1,9 +1,6 @@
 package com.sportisfun.backend.models;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.Min;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -23,13 +20,14 @@ public class Odds {
     @GeneratedValue
     private Long id;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="match_id", nullable=false, unique=true)
     private Match match;
 
-    @Min(1)
+    @Column(precision=8, scale=2, nullable=false)
     private BigDecimal homeWin;
-    @Min(1)
+    @Column(precision=8, scale=2, nullable=false)
     private BigDecimal draw;
-    @Min(1)
+    @Column(precision=8, scale=2, nullable=false)
     private BigDecimal awayWin;
 }

--- a/backend/src/main/java/com/sportisfun/backend/models/Team.java
+++ b/backend/src/main/java/com/sportisfun/backend/models/Team.java
@@ -1,10 +1,7 @@
 package com.sportisfun.backend.models;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.List;
 
@@ -25,6 +22,8 @@ public class Team {
     //@Column(nullable = false)
     private String logoUrl;
 
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
     @ManyToOne
     @JoinColumn(name="league_id")
     private League league;

--- a/backend/src/main/java/com/sportisfun/backend/models/User.java
+++ b/backend/src/main/java/com/sportisfun/backend/models/User.java
@@ -27,13 +27,14 @@ public class User {
     private String username;
 
     @Email
-    @Column(unique = true, nullable = false)
+    @Column(unique = true, nullable = false, length = 100)
     private String email;
 
     @Size(min = 8)
     @Column(nullable = false)
     private String password;
 
+    @Enumerated(EnumType.STRING)
     private Role role;
 
     @OneToMany(

--- a/backend/src/main/java/com/sportisfun/backend/repositories/BetSlipRepository.java
+++ b/backend/src/main/java/com/sportisfun/backend/repositories/BetSlipRepository.java
@@ -1,9 +1,16 @@
 package com.sportisfun.backend.repositories;
 
 import com.sportisfun.backend.models.BetSlip;
+import com.sportisfun.backend.models.BetSlipStatus;
+import com.sportisfun.backend.models.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
 @Repository
 public interface BetSlipRepository extends JpaRepository<BetSlip, Long> {
+    List<BetSlip> findAllByUserId(Long id);
+    Optional<BetSlip> findFirstByUser_IdAndStatus(Long id, BetSlipStatus status);
 }

--- a/backend/src/main/java/com/sportisfun/backend/services/BetSlipService.java
+++ b/backend/src/main/java/com/sportisfun/backend/services/BetSlipService.java
@@ -1,0 +1,147 @@
+package com.sportisfun.backend.services;
+
+import com.sportisfun.backend.DTOs.AddPickDto;
+import com.sportisfun.backend.DTOs.BetPickDto;
+import com.sportisfun.backend.DTOs.BetSlipDto;
+import com.sportisfun.backend.DTOs.PlaceBetSlipRequest;
+import com.sportisfun.backend.models.*;
+import com.sportisfun.backend.repositories.BetPickRepository;
+import com.sportisfun.backend.repositories.BetSlipRepository;
+import com.sportisfun.backend.repositories.MatchRepository;
+import com.sportisfun.backend.repositories.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BetSlipService {
+
+    private final UserRepository userRepository;
+    private final BetSlipRepository betSlipRepository;
+    private final MatchRepository matchRepository;
+    private final BetPickRepository betPickRepository;
+
+    @Transactional(readOnly = true)
+    public BetSlipDto getDraft(Long id){
+        User user = userRepository.findById(id).orElseThrow(() -> new IllegalStateException("User not found"));
+        BetSlip slip = betSlipRepository.findFirstByUser_IdAndStatus(id, BetSlipStatus.DRAFT).orElse(null);
+        if(slip == null){
+            return null;
+        }
+        return mapToBetSlipDto(slip);
+    }
+
+    @Transactional
+    public BetSlipDto addPick(AddPickDto addPickDto, Long id){
+        User user =  userRepository.findById(id).orElseThrow(() -> new IllegalStateException("User not found"));
+        BetSlip slip = betSlipRepository.findFirstByUser_IdAndStatus(id, BetSlipStatus.DRAFT)
+                .orElseGet(() -> {
+                        BetSlip s = BetSlip.builder()
+                                    .user(user)
+                                    .status(BetSlipStatus.DRAFT)
+                                    .totalOdds(BigDecimal.ONE)
+                                    .build();
+                        return betSlipRepository.save(s);
+                        });
+        // This may cause problem cuz we cast from long to int later we have to change it!!!
+        Match match = matchRepository.findById(Math.toIntExact(addPickDto.getMatchId())).orElseThrow(
+                () -> new IllegalArgumentException("Match with id: " + addPickDto.getMatchId() + " does not exist")
+        );
+        if(match.isFinished()){
+            throw new IllegalStateException("Cannot add match that has already ended");
+        }
+        boolean alreadyInSlip = slip.getBetPicks().stream()
+                .anyMatch(p -> p.getMatch().getId().equals(match.getId()));
+        if(alreadyInSlip){
+            throw new IllegalStateException("Match is already in slip. Remove it first");
+        }
+
+        BigDecimal odd = extractOdds(addPickDto.getBetOption(), match.getOdds());
+        BetPick pick = BetPick.builder()
+                .match(match)
+                .result(BetPickResult.PENDING)
+                .selectedOdd(odd)
+                .betOption(addPickDto.getBetOption())
+                .build();
+
+        slip.addPick(pick);
+        betSlipRepository.save(slip);
+        return mapToBetSlipDto(slip);
+    }
+
+    @Transactional
+    public BetSlipDto removePick(Long pickId, Long userId){
+        User user = userRepository.findById(userId).orElseThrow(() -> new IllegalStateException("User not found"));
+        BetSlip slip = betSlipRepository.findFirstByUser_IdAndStatus(userId, BetSlipStatus.DRAFT).orElseThrow(() ->
+                new IllegalStateException("There is no active bet slip to remove from"));
+
+        BetPick pick = betPickRepository.findById(pickId).orElseThrow(() ->
+                new IllegalStateException("Pick with id: " + pickId + " does not exist"));
+
+        if(!slip.getBetPicks().contains(pick)){
+            throw new IllegalStateException("Pick with id: " + pickId + " does not exist in current slip");
+        }
+
+        slip.removePick(pick);
+        betSlipRepository.save(slip);
+        return mapToBetSlipDto(slip);
+    }
+
+    @Transactional
+    public BetSlipDto place(PlaceBetSlipRequest req, Long userId){
+        User user = userRepository.findById(userId).orElseThrow(() -> new IllegalStateException("User not found"));
+        BetSlip slip = betSlipRepository.findFirstByUser_IdAndStatus(userId, BetSlipStatus.DRAFT).orElseThrow(() ->
+                new IllegalStateException("There is no active bet slip"));
+        if(slip.getBetPicks().isEmpty()){
+            throw new IllegalStateException("Bet slip must contain at least one pick");
+        }
+        slip.place(req.getStake());
+        betSlipRepository.save(slip);
+        return mapToBetSlipDto(slip);
+    }
+
+    private BigDecimal extractOdds(BetOption betOption, Odds odds){
+        if(odds == null){
+            throw new IllegalArgumentException("There are no odds for this match");
+        }
+        if(betOption.equals(BetOption.AWAY)){
+            return odds.getAwayWin();
+        } else if (betOption.equals(BetOption.HOME)) {
+            return odds.getHomeWin();
+        } else {
+            return odds.getDraw();
+        }
+    }
+
+
+    private BetSlipDto mapToBetSlipDto(BetSlip slip){
+        Set<BetPickDto> picks = slip.getBetPicks().stream()
+                .map(p -> BetPickDto.builder()
+                        .id(p.getId())
+                        .matchId(p.getMatch().getId())
+                        .option(p.getBetOption())
+                        .selectedOdds(p.getSelectedOdd())
+                        .result(p.getResult())
+                        .build())
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        return BetSlipDto.builder()
+                .id(slip.getId())
+                .stake(slip.getStake())
+                .status(slip.getStatus())
+                .totalOdds(slip.getTotalOdds())
+                .potentialWin(slip.getPotentialWin())
+                .placedAt(slip.getPlacedAt())
+                .settledAt(slip.getSettledAt())
+                .betPicks(picks)
+                .build();
+    }
+}


### PR DESCRIPTION
This pull request introduces a complete backend implementation for managing bet slips and picks, including new data transfer objects (DTOs), models, controller endpoints, repository queries, and service logic. The main focus is to support creating, updating, placing, and settling bet slips, with robust validation and proper entity relationships.

### Backend bet slip management

* Added `BetSlipController` with endpoints to get the draft slip, add/remove picks, and place a bet slip, using new DTOs for request/response payloads.
* Implemented `BetSlipService` to handle core business logic for bet slip operations, including validation, odds extraction, and mapping entities to DTOs.
* Created DTOs for adding picks (`AddPickDto`), bet picks (`BetPickDto`), bet slips (`BetSlipDto`), and placing bet slips (`PlaceBetSlipRequest`). [[1]](diffhunk://#diff-ce5190b86646d0608e55e8672ba4ec5ee6ba5073e6f2719d7a6ff0c5cc7f77c9R1-R13) [[2]](diffhunk://#diff-adce472a7ed3451021094b53520da627e74a50714a2796efbd9353d8255ae245R1-R18) [[3]](diffhunk://#diff-2156462151b523dea56dc5a4f65c05c1b9224f14a91e19feb74acf1be0110e1bR1-R23) [[4]](diffhunk://#diff-92edb67a63ca2710c39fd7352a4facd502509e9b06e0106bc482d0bd8d203255R1-R14)

### Entity and relationship enhancements

* Updated `BetSlip` and `BetPick` models: added status enums, odds fields, lifecycle methods (add/remove/place/settle), and improved entity relationships and validation. [[1]](diffhunk://#diff-67cfd7fbd18f9e273e484289e86b8e6b8ad7ae000ab422a1a2f31a4c04f70d4cL27-R105) [[2]](diffhunk://#diff-6e77679e27fe9bc1e53603a171db674da956c12c76d3f78d33d6e64628700d6bR5-R35) [[3]](diffhunk://#diff-7ad4aae3d51e5c094d13d91be5cbde3186f25a4164eb914081a7698fedcb4be7R1-R7) [[4]](diffhunk://#diff-a55cb36d8452e448e5cc2f647de4e1b941222bf21a00c0a36cfa75ed90bb08b9R1-R7)
* Improved `Match`, `Odds`, `League`, and `Team` models for better relationship handling, lazy loading, and exclusion from string/hash code methods to prevent recursion and performance issues. [[1]](diffhunk://#diff-5e3d665babb53d9df68aeb78c0b23f70d4b507368176fb74432e3d11cb622007L21-R50) [[2]](diffhunk://#diff-d88e0f2745c5658e5225108cd67f839b6bc6b4c3cff87e2eb1137e9abc28b0f8L26-R31) [[3]](diffhunk://#diff-e1060c02362c08996e5664d300ca453f82d6166f76e7729dc6b3ecc3b0fbf545R26-R27) [[4]](diffhunk://#diff-4f3ba25a641a805302e992249383168a8175a9eed5b079a20df3933a923b9f9cR25-R26)

### Repository and persistence improvements

* Extended `BetSlipRepository` with queries to find slips by user and status, supporting draft management and placement workflows.